### PR TITLE
Fix for older Git.py

### DIFF
--- a/scripts/system-info.py
+++ b/scripts/system-info.py
@@ -275,7 +275,7 @@ def get_version():
             githash, updated = ver.split(' ')
             res = subprocess.run('git remote get-url origin', stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True, check=True)
             origin = res.stdout.decode(encoding = 'utf8', errors='ignore') if len(res.stdout) > 0 else ''
-            res = subprocess.run('git branch --show-current', stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True, check=True)
+            res = subprocess.run('git rev-parse --abbrev-ref HEAD', stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True, check=True)
             branch = res.stdout.decode(encoding = 'utf8', errors='ignore') if len(res.stdout) > 0 else ''
             version = {
                 'updated': updated,


### PR DESCRIPTION
`git branch --show-current` only works for Git 2.22 or above. Using `git rev-parse --abbrev-ref HEAD` enables older versions(1.7+) of Git to function properly