### PR TITLE
feat: read keyword from the current url to fill in the search box

### DIFF
--- a/pages/benchmark.html
+++ b/pages/benchmark.html
@@ -51,6 +51,7 @@
     <script type="module">
       import { Grid, html } from 'https://cdn.jsdelivr.net/npm/gridjs@6.0.6/dist/gridjs.module.js'; // eslint-disable-line import/no-unresolved, node/no-missing-import, import/extensions
 
+      const currentUrl = new URL(location.href);
       const dataUrl = 'https://vladmandic.github.io/sd-data/pages/benchmark-data.json';
 
       const log = (...msg) => {
@@ -105,7 +106,9 @@
             limit: 200,
             summary: true,
           },
-          search: true,
+          search: {
+            keyword: currentUrl.searchParams.get('keyword') || ''
+          },
           sort: { multiColumn: false },
           resizable: true,
           fixedHeader: true,


### PR DESCRIPTION
Usage (serve via `cd pages && python3 -m http.server`):

* http://127.0.0.1:8000/benchmark.html?keyword=RX%207900%20XTX
* http://127.0.0.1:8000/benchmark.html?keyword=RTX%204090
