### PR TITLE
Fix IPEX with torch.version.cuda hijack

### DIFF
--- a/scripts/system-info.py
+++ b/scripts/system-info.py
@@ -87,14 +87,10 @@ def get_gpu():
     else:
         try:
             if hasattr(torch, "xpu") and torch.xpu.is_available():
-                try:
-                    import intel_extension_for_pytorch # pylint: disable=import-error, unused-import
-                    return {
-                        'device': f'{torch.xpu.get_device_name(torch.xpu.current_device())} ({str(torch.xpu.device_count())})',
-                        'ipex': get_package_version('intel-extension-for-pytorch'),
-                    }
-                except Exception as e:
-                    return { 'error': e }
+                return {
+                    'device': f'{torch.xpu.get_device_name(torch.xpu.current_device())} ({str(torch.xpu.device_count())})',
+                    'ipex': get_package_version('intel-extension-for-pytorch'),
+                }
             elif torch.version.cuda:
                 return {
                     'device': f'{torch.cuda.get_device_name(torch.cuda.current_device())} ({str(torch.cuda.device_count())}) ({torch.cuda.get_arch_list()[-1]}) {str(torch.cuda.get_device_capability(shared.device))}',


### PR DESCRIPTION
Hijacking torch.version.cuda gives %15 extra boost on Diffusers.
But hijacking torch.version.cuda breaks System Info.
This PR fixes it.